### PR TITLE
Add subxt tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ cargo build --release
 ```
 The binary will be available at `./target/release/substrate-mcp`
 
+## Prerequisites
+
+For the `subxt_execute` tool, install the subxt CLI:
+```bash
+cargo install subxt-cli
+```
+
+## Available Tools
+
+- **`get_polkadot_sdk_release_prdocs`** - Get documented changes for polkadot-sdk releases
+- **`chain_storage_bisect`** - Find storage changes between blocks for a specific key
+- **`subxt_execute`** - Decode metadata, generate type-safe code, and explore Substrate chains
+
 ## Usage with Claude Code
 
 To use this MCP server with Claude Code, add it to your Claude Code configuration.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use rmcp::service::ServiceExt;
 use tokio::io::{stdin, stdout};
 
 mod polkadot_sdk_releases;
+mod public_endpoints;
 mod server;
 mod substrate;
 

--- a/src/public_endpoints.rs
+++ b/src/public_endpoints.rs
@@ -1,0 +1,45 @@
+/// Public RPC endpoints for various Substrate-based chains
+#[allow(dead_code)]
+pub mod endpoints {
+    /// Polkadot mainnet
+    pub const POLKADOT: &str = "wss://rpc.polkadot.io";
+    
+    /// Kusama canary network
+    pub const KUSAMA: &str = "wss://kusama-rpc.polkadot.io";
+    
+    /// Westend testnet
+    pub const WESTEND: &str = "wss://westend-rpc.polkadot.io";
+    
+    /// Rococo testnet
+    pub const ROCOCO: &str = "wss://rococo-rpc.polkadot.io";
+    
+    /// Paseo testnet (replaced Rococo for parachains)
+    pub const PASEO: &str = "wss://paseo.rpc.amforc.com";
+    
+    /// Asset Hub on Polkadot
+    pub const ASSET_HUB_POLKADOT: &str = "wss://polkadot-asset-hub-rpc.polkadot.io";
+    
+    /// Asset Hub on Kusama  
+    pub const ASSET_HUB_KUSAMA: &str = "wss://kusama-asset-hub-rpc.polkadot.io";
+    
+    /// Asset Hub on Westend
+    pub const ASSET_HUB_WESTEND: &str = "wss://westend-asset-hub-rpc.polkadot.io";
+    
+    /// Default endpoint (Westend testnet is a good default for testing)
+    pub const DEFAULT: &str = WESTEND;
+}
+
+/// Get a user-friendly name for a chain from its endpoint
+pub fn chain_name_from_endpoint(endpoint: &str) -> &'static str {
+    match endpoint {
+        e if e.contains("polkadot") && !e.contains("kusama") && !e.contains("westend") => "Polkadot",
+        e if e.contains("kusama") => "Kusama",
+        e if e.contains("westend") => "Westend",
+        e if e.contains("rococo") => "Rococo",
+        e if e.contains("paseo") => "Paseo",
+        e if e.contains("asset-hub") && e.contains("polkadot") => "Asset Hub Polkadot",
+        e if e.contains("asset-hub") && e.contains("kusama") => "Asset Hub Kusama",
+        e if e.contains("asset-hub") && e.contains("westend") => "Asset Hub Westend",
+        _ => "Custom Chain"
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,8 @@ use rmcp::model::{
 };
 use rmcp::{schemars, tool, tool_handler, tool_router, ErrorData as McpError};
 use std::future::Future;
+use std::process::Stdio;
+use tokio::process::Command;
 
 use crate::polkadot_sdk_releases;
 use serde::Deserialize;
@@ -28,6 +30,12 @@ pub struct SubstrateService {
 pub struct GetPolkadotSdkReleasePrdocsRequest {
     /// polkadot-sdk release (examples: '1.9.0', 'stable2412-1', 'stable2412')
     pub release: String,
+}
+
+#[derive(Debug, Deserialize, Clone, schemars::JsonSchema)]
+pub struct SubxtExecuteArgs {
+    /// The subxt command and arguments to execute (e.g., ["metadata", "-f", "json", "--url", "ws://localhost:9944"])
+    pub args: Vec<String>,
 }
 
 #[tool_router]
@@ -71,9 +79,10 @@ impl SubstrateService {
     ) -> Result<CallToolResult, McpError> {
         let url = args
             .rpc_url
-            .unwrap_or_else(|| "http://127.0.0.1:9944".to_string());
+            .unwrap_or_else(|| crate::public_endpoints::endpoints::DEFAULT.to_string());
 
-        log::info!("Connecting to Substrate node at {url}...");
+        let chain_name = crate::public_endpoints::chain_name_from_endpoint(&url);
+        log::info!("Connecting to {} at {}", chain_name, url);
         let client = SubstrateClient::connect(&url).await.map_err(|e| McpError {
             code: rmcp::model::ErrorCode(-32603),
             message: e.to_string().into(),
@@ -106,6 +115,64 @@ impl SubstrateService {
                 data: None,
             }),
         }
+    }
+
+    #[tool(
+        description = "Use subxt to decode and explore Substrate blockchain data. Useful for: analyzing chain metadata structure, generating type-safe Rust code for chain interactions, exploring available pallets/calls/storage/events, decoding extrinsics and storage values, and understanding runtime APIs. The 'explore' subcommand provides interactive browsing of chain state. Common investigations: System.LastRuntimeUpgrade (find runtime upgrades), Staking.ActiveEra (current era info), Democracy.ReferendumCount (governance activity). Outputs human-readable decoded values by default. Particularly valuable when building applications that need to interact with Substrate chains or when investigating chain functionality. Pass '--help' to any subcommand to learn more."
+    )]
+    pub async fn subxt_execute(
+        &self,
+        Parameters(args): Parameters<SubxtExecuteArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        if args.args.is_empty() {
+            return Err(McpError {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "No arguments provided for subxt command".into(),
+                data: None,
+            });
+        }
+
+        log::info!("Executing subxt with args: {:?}", args.args);
+
+        let output = Command::new("subxt")
+            .args(&args.args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| McpError {
+                code: rmcp::model::ErrorCode(-32603),
+                message: format!("Failed to execute subxt: {e}. Make sure subxt is installed.").into(),
+                data: None,
+            })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if !output.status.success() {
+            return Err(McpError {
+                code: rmcp::model::ErrorCode(-32603),
+                message: format!("subxt command failed: {}", stderr).into(),
+                data: None,
+            });
+        }
+
+        let result = if !stdout.is_empty() {
+            stdout.to_string()
+        } else if !stderr.is_empty() {
+            // Some subxt commands output to stderr even on success
+            stderr.to_string()
+        } else {
+            "Command completed successfully with no output".to_string()
+        };
+
+        Ok(CallToolResult {
+            content: vec![Content {
+                annotations: None,
+                raw: RawContent::Text(RawTextContent { text: result }),
+            }],
+            is_error: None,
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds the [subxt tool](https://github.com/paritytech/subxt).

The tool's `document` field is a work in progress, it seems to have a huge impact on how effectively and efficiently the tool can use it. I'm finding that giving `claude` some exercises (like "find the last runtime upgrade on Polkadot") followed by "did this give you more context you'd like to add to the tool description?" is extremely useful.