### PR TITLE
Return extrinsic results on `submit_dev_extrinsic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ cargo install subxt-cli
 - **`query_events`** - Query and filter blockchain events within a specified block range. Supports filtering by pallet and event name with partial matching.
 - **`query_historical_events`** - Query events from historical blocks. Supports relative block numbers (e.g., -10 for 10 blocks ago).
 
+### Extrinsic Operations
+- **`submit_dev_extrinsic`** - Submit an extrinsic to a Substrate chain using dev accounts (alice, bob, charlie, etc.).
+
 ### Storage Querying
 - **`query_storage`** - Query chain storage entries by pallet and storage name. Supports querying map-type storage with keys.
 - **`list_pallet_storage`** - List all storage entries available in a specific pallet.

--- a/src/server.rs
+++ b/src/server.rs
@@ -489,7 +489,7 @@ impl SubstrateService {
     }
 
     #[tool(
-        description = "Submit a generic extrinsic to a Substrate chain using dev accounts. Supports any pallet call with arbitrary arguments. Use dev account names like 'alice', 'bob', 'charlie', etc. for signing. Recommend using filter_metadata first to understand argument format. Arguments must be in scale_value string format and will be parsed using scale_value::stringify::from_str - consult the 'substrate:scale-value-format' resource for detailed syntax and examples."
+        description = "Submit a generic extrinsic to a Substrate chain using dev accounts. Supports any pallet call with arbitrary arguments. Use dev account names like 'alice', 'bob', 'charlie', etc. for signing. Recommend using filter_metadata first to understand argument format. Arguments must be in scale_value string format and will be parsed using scale_value::stringify::from_str - consult the 'substrate:scale-value-format' resource for detailed syntax and examples, consulting this is especially important when dealing with calls that involve accounts/addresses."
     )]
     pub async fn submit_dev_extrinsic(
         &self,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -87,20 +87,51 @@ pub async fn handle_submit_dev_extrinsic(
             data: None,
         })?;
 
-    // Wait for the transaction to be finalized
-    let tx_in_block = tx_progress
-        .wait_for_finalized()
+    // Wait for the transaction to be finalized and check for success
+    let tx_events = tx_progress
+        .wait_for_finalized_success()
         .await
         .map_err(|e| McpError {
             code: rmcp::model::ErrorCode(-32603),
-            message: format!("Failed to wait for transaction finalization: {e}").into(),
+            message: format!("Transaction failed: {e}").into(),
             data: None,
         })?;
 
+    let mut events_info = Vec::new();
+    for event in tx_events.iter() {
+        let event = event.map_err(|e| McpError {
+            code: rmcp::model::ErrorCode(-32603),
+            message: format!("Failed to decode event: {e}").into(),
+            data: None,
+        })?;
+
+        let fields = event.field_values().map_err(|e| McpError {
+            code: rmcp::model::ErrorCode(-32603),
+            message: format!("Failed to decode event fields: {e}").into(),
+            data: None,
+        })?;
+
+        let value = scale_value::Value {
+            value: scale_value::ValueDef::Composite(fields),
+            context: 0,
+        };
+        let fields_str = scale_value::stringify::to_string(&value);
+
+        // Concatenate event name with the fields data
+        let event_data = format!(
+            "  - {}.{}: {}",
+            event.pallet_name(),
+            event.variant_name(),
+            fields_str
+        );
+
+        events_info.push(event_data);
+    }
+
     let result = format!(
-        "Transaction finalized. Hash: {:?}, Block hash: {:?}",
-        tx_in_block.extrinsic_hash(),
-        tx_in_block.block_hash()
+        "Transaction successful!\nHash: {:?}\nEvents emitted:\n{}",
+        tx_events.extrinsic_hash(),
+        events_info.join("\n")
     );
 
     Ok(CallToolResult {


### PR DESCRIPTION
Uses `wait_for_finalized_success` that will error if transaction was not successful and get event data for the transaction it it was. This gives agent actual transaction feedback without  it needing to query transaction data again and prevents mistakes like thinking a transaction succeeded when in fact it didn't.