### PR TITLE
Add panic wrapper for tools

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -14,6 +14,8 @@ pub mod resources;
 pub mod tools;
 mod utils;
 
+use utils::catch_panic_as_mcp_error;
+
 #[derive(Clone)]
 pub struct SubstrateService {
     tool_router: ToolRouter<Self>,
@@ -40,7 +42,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::FetchAndAnalyzeReleaseProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_fetch_and_analyze_release(properties).await
+        catch_panic_as_mcp_error(tools::handle_fetch_and_analyze_release(properties)).await
     }
 
     #[tool(
@@ -50,7 +52,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::SubxtExecuteProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_subxt_execute(properties).await
+        catch_panic_as_mcp_error(tools::handle_subxt_execute(properties)).await
     }
 
     #[tool(
@@ -60,7 +62,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::MetadataFilterProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_filter_metadata(properties).await
+        catch_panic_as_mcp_error(tools::handle_filter_metadata(properties)).await
     }
 
     #[tool(
@@ -70,7 +72,10 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::QueryEventsProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_query_events(properties).await
+        catch_panic_as_mcp_error(catch_panic_as_mcp_error(tools::handle_query_events(
+            properties,
+        )))
+        .await
     }
 
     #[tool(
@@ -80,7 +85,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::QueryStorageProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_query_storage(properties).await
+        catch_panic_as_mcp_error(tools::handle_query_storage(properties)).await
     }
 
     #[tool(
@@ -90,7 +95,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::ListPalletStorageProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_list_pallet_storage(properties).await
+        catch_panic_as_mcp_error(tools::handle_list_pallet_storage(properties)).await
     }
 
     #[tool(
@@ -100,7 +105,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::SubmitExtrinsicProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_submit_dev_extrinsic(properties).await
+        catch_panic_as_mcp_error(tools::handle_submit_dev_extrinsic(properties)).await
     }
 
     #[tool(
@@ -110,7 +115,7 @@ impl SubstrateService {
         &self,
         Parameters(properties): Parameters<tools::QueryExtrinsicsProperties>,
     ) -> Result<CallToolResult, McpError> {
-        tools::handle_query_extrinsics(properties).await
+        catch_panic_as_mcp_error(tools::handle_query_extrinsics(properties)).await
     }
 }
 

--- a/src/service/utils.rs
+++ b/src/service/utils.rs
@@ -1,4 +1,7 @@
+use futures::FutureExt;
+use rmcp::model::CallToolResult;
 use rmcp::ErrorData as McpError;
+use std::panic::AssertUnwindSafe;
 
 pub fn mcp_error_internal(message: String) -> McpError {
     McpError {
@@ -14,4 +17,27 @@ pub fn mcp_error_invalid_params(message: String) -> McpError {
         message: message.into(),
         data: None,
     }
+}
+
+/// Executes a handler and returns mcp error on panic.
+pub async fn catch_panic_as_mcp_error<F>(future: F) -> Result<CallToolResult, McpError>
+where
+    F: std::future::Future<Output = Result<CallToolResult, McpError>> + Send,
+{
+    AssertUnwindSafe(future)
+        .catch_unwind()
+        .await
+        .unwrap_or_else(|panic| {
+            let panic_msg = if let Some(s) = panic.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = panic.downcast_ref::<&str>() {
+                s.to_string()
+            } else {
+                "Unknown panic".to_string()
+            };
+
+            Err(mcp_error_internal(format!(
+                "Call panicked: {panic_msg}. This is a bug. Please report it to substrate-mcp mantainers.",
+            )))
+        })
 }


### PR DESCRIPTION
For MCP calls via stdio transport, if there's a panic in the tokio task spawned to deal with the tool, there will be nothing logged back via `stdout` and this leads to unexpected behaviour. This adds a basic handler that we catch a panic and transform it into an `McpError`