### PR TITLE
bump rmcp to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f521fbd040eba82684b17d787d423f43afb6e97974029b51f679157a589592a"
+checksum = "c7dd163d26e254725137b7933e4ba042ea6bf2d756a4260559aaea8b6ad4c27e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3997,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c162bf8a2846f70464ded6dda6430b60d1e2fb4b0e371f0906e39f63916641b9"
+checksum = "a43bb4c90a0d4b12f7315eb681a73115d335a2cee81322eca96f3467fe4cd06f"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rmcp = { version = "0.6.1", features = ["transport-io"] }
+rmcp = { version = "0.6.3", features = ["transport-io"] }
 indoc = "2.0.6"
 schemars = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An MCP (Model Context Protocol) server that provides tools for working with Subs
 
 ### Option 1: Install from GitHub
 ```bash
-cargo install --git https://github.com/Moonsong-Labs/substrate-mcp
+cargo install --locked --git https://github.com/Moonsong-Labs/substrate-mcp
 ```
 
 ### Option 2: Build locally (Requires cargo)

--- a/src/service/resources.rs
+++ b/src/service/resources.rs
@@ -26,7 +26,7 @@ impl From<SubstrateResource> for Resource {
             Some(Annotations {
                 audience: None,
                 priority: Some(val.priority),
-                timestamp: None,
+                last_modified: None,
             }),
         )
     }

--- a/src/service/tools/mod.rs
+++ b/src/service/tools/mod.rs
@@ -43,6 +43,7 @@ pub(crate) async fn handle_fetch_and_analyze_release(
         annotations: None,
         raw: RawContent::Text(RawTextContent {
             text: response_text,
+            meta: None,
         }),
     }]);
     Ok(result)
@@ -140,7 +141,10 @@ pub(crate) async fn handle_submit_dev_extrinsic(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: result_text }),
+        raw: RawContent::Text(RawTextContent {
+            text: result_text,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }
@@ -194,7 +198,10 @@ pub(crate) async fn handle_subxt_execute(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: result }),
+        raw: RawContent::Text(RawTextContent {
+            text: result,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }
@@ -243,7 +250,10 @@ pub(crate) async fn handle_filter_metadata(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: json_result }),
+        raw: RawContent::Text(RawTextContent {
+            text: json_result,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }
@@ -289,7 +299,10 @@ pub(crate) async fn handle_query_events(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: json_result }),
+        raw: RawContent::Text(RawTextContent {
+            text: json_result,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }
@@ -338,7 +351,10 @@ pub(crate) async fn handle_query_storage(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: json_result }),
+        raw: RawContent::Text(RawTextContent {
+            text: json_result,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }
@@ -370,7 +386,10 @@ pub(crate) async fn handle_list_pallet_storage(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: json_result }),
+        raw: RawContent::Text(RawTextContent {
+            text: json_result,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }
@@ -424,7 +443,10 @@ pub(crate) async fn handle_query_extrinsics(
 
     let result = CallToolResult::success(vec![Content {
         annotations: None,
-        raw: RawContent::Text(RawTextContent { text: json_result }),
+        raw: RawContent::Text(RawTextContent {
+            text: json_result,
+            meta: None,
+        }),
     }]);
     Ok(result)
 }


### PR DESCRIPTION
Trying to `cargo install` `substrate-mcp` was failing because `rmcp` added breaking changes to a patch release. Updated to latest patch and updated `README` to use `--locked` to prevent cases like these.  