### PR TITLE
chore: upgrade rmcp from 0.6.3 to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1039,12 +1039,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.0",
- "darling_macro 0.21.0",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1077,11 +1077,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1113,11 +1112,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.0",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -3471,6 +3470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,14 +4039,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dd163d26e254725137b7933e4ba042ea6bf2d756a4260559aaea8b6ad4c27e"
+checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
@@ -4056,11 +4062,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43bb4c90a0d4b12f7315eb681a73115d335a2cee81322eca96f3467fe4cd06f"
+checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
 dependencies = [
- "darling 0.21.0",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rmcp = { version = "0.6.3", features = ["transport-io"] }
+rmcp = { version = "0.13.0", features = ["transport-io"] }
 indoc = "2.0.6"
 schemars = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -47,5 +47,5 @@ ignore = "0.4.23"
 async-trait = "0.1"
 
 [dev-dependencies]
-rmcp = { version = "0.6.3", features = ["transport-io", "client"] }
+rmcp = { version = "0.13.0", features = ["transport-io", "client"] }
 tempfile = "3.22.0"

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -223,6 +223,9 @@ impl ServerHandler for SubstrateService {
             server_info: rmcp::model::Implementation {
                 name: "substrate-mcp".to_string(),
                 version: "0.1.0".to_string(),
+                title: Some("Substrate MCP Server".to_string()),
+                icons: None,
+                website_url: Some("https://github.com/Moonsong-Labs/substrate-mcp".to_string()),
             },
             instructions: Some("Primary source for Substrate/Polkadot SDK development. Provides authoritative tools for chain interaction, release documentation, prompt templates and comprehensive Substrate knowledge resources.".into()),
             capabilities: ServerCapabilities::builder()

--- a/src/service/resources.rs
+++ b/src/service/resources.rs
@@ -25,6 +25,9 @@ impl From<MarkdownResource> for Resource {
                 description: Some(val.description),
                 mime_type: Some("text/markdown".to_string()),
                 size: Some(val.content.len() as u32),
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: val.audience,
@@ -215,6 +218,9 @@ fn https_resources() -> Vec<Resource> {
                 description: Some("Index with LLM friendly Polkadot documentation. Use this to get proper context on how Polkadot works or how to perform a specific task within Polkadot or Substrate based chains (e.g: create a pallet, add benchmarks or work with XCM)".into()),
                 mime_type: None,
                 size: None,
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: Some(vec![Role::Assistant]),
@@ -229,6 +235,9 @@ fn https_resources() -> Vec<Resource> {
                 description: Some("Polkadot SDK GitHub Repository.".into()),
                 mime_type: None,
                 size: None,
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: Some(vec![Role::Assistant, Role::User]),
@@ -243,6 +252,9 @@ fn https_resources() -> Vec<Resource> {
                 description: Some("`polkadot-sdk` crate documentation".into()),
                 mime_type: None,
                 size: None,
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: Some(vec![Role::Assistant, Role::User]),

--- a/src/service/tests/helpers/mcp_client.rs
+++ b/src/service/tests/helpers/mcp_client.rs
@@ -49,6 +49,7 @@ impl TestMcpClient {
         let request = CallToolRequestParam {
             name: Cow::from(name.to_string()),
             arguments: args,
+            task: None,
         };
         Ok(self.client.call_tool(request).await?)
     }


### PR DESCRIPTION
The upgrade brings new features like graceful shutdown, task support, and elicitation improvements which can be adopted in future updates.