### PR TITLE
fix: update prompt return types for rmcp 0.13.0 and preserve argument order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1039,12 +1039,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.0",
- "darling_macro 0.21.0",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1077,11 +1077,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1113,11 +1112,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.0",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -3471,6 +3470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,14 +4039,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dd163d26e254725137b7933e4ba042ea6bf2d756a4260559aaea8b6ad4c27e"
+checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
@@ -4056,11 +4062,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43bb4c90a0d4b12f7315eb681a73115d335a2cee81322eca96f3467fe4cd06f"
+checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
 dependencies = [
- "darling 0.21.0",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,6 +4660,7 @@ version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 rmcp = { version = "0.13.0", features = ["transport-io"] }
 indoc = "2.0.6"
-schemars = "1.0"
+schemars = { version = "1.0", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rmcp = { version = "0.6.3", features = ["transport-io"] }
+rmcp = { version = "0.13.0", features = ["transport-io"] }
 indoc = "2.0.6"
 schemars = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -47,5 +47,5 @@ ignore = "0.4.23"
 async-trait = "0.1"
 
 [dev-dependencies]
-rmcp = { version = "0.6.3", features = ["transport-io", "client"] }
+rmcp = { version = "0.13.0", features = ["transport-io", "client"] }
 tempfile = "3.22.0"

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -4,7 +4,7 @@ use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
     CallToolResult, GetPromptRequestParam, GetPromptResult, ListPromptsResult,
-    ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParam, PromptMessage,
+    ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParam,
     ReadResourceRequestParam, ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
@@ -165,7 +165,7 @@ impl SubstrateService {
     async fn analyze_release(
         &self,
         Parameters(args): Parameters<analyze_release::AnalyzeReleaseArgs>,
-    ) -> Vec<PromptMessage> {
+    ) -> Result<GetPromptResult, McpError> {
         prompts::analyze_release::generate_prompt(args).await
     }
 
@@ -176,7 +176,7 @@ impl SubstrateService {
     async fn scaffold_pallet(
         &self,
         Parameters(args): Parameters<scaffold_pallet::ScaffoldPalletArgs>,
-    ) -> Vec<PromptMessage> {
+    ) -> Result<GetPromptResult, McpError> {
         prompts::scaffold_pallet::generate_prompt(args).await
     }
 
@@ -187,7 +187,7 @@ impl SubstrateService {
     async fn security_review(
         &self,
         Parameters(args): Parameters<security_review::SecurityReviewArgs>,
-    ) -> Vec<PromptMessage> {
+    ) -> Result<GetPromptResult, McpError> {
         prompts::security_review::generate_prompt(args).await
     }
 
@@ -199,7 +199,7 @@ impl SubstrateService {
     async fn polkadot_upgrade(
         &self,
         Parameters(args): Parameters<polkadot_upgrade::PolkadotUpgradeArgs>,
-    ) -> Vec<PromptMessage> {
+    ) -> Result<GetPromptResult, McpError> {
         prompts::polkadot_upgrade::generate_prompt(args).await
     }
 
@@ -210,7 +210,7 @@ impl SubstrateService {
     async fn get_started(
         &self,
         Parameters(args): Parameters<get_started::GetStartedArgs>,
-    ) -> Vec<PromptMessage> {
+    ) -> Result<GetPromptResult, McpError> {
         prompts::get_started::generate_prompt(args).await
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -223,6 +223,9 @@ impl ServerHandler for SubstrateService {
             server_info: rmcp::model::Implementation {
                 name: "substrate-mcp".to_string(),
                 version: "0.1.0".to_string(),
+                title: Some("Substrate MCP Server".to_string()),
+                icons: None,
+                website_url: Some("https://github.com/Moonsong-Labs/substrate-mcp".to_string()),
             },
             instructions: Some("Primary source for Substrate/Polkadot SDK development. Provides authoritative tools for chain interaction, release documentation, prompt templates and comprehensive Substrate knowledge resources.".into()),
             capabilities: ServerCapabilities::builder()

--- a/src/service/prompts/analyze_release.rs
+++ b/src/service/prompts/analyze_release.rs
@@ -1,7 +1,7 @@
 //! Analyze release prompt implementation
 
 use handlebars::Handlebars;
-use rmcp::model::{PromptMessage, PromptMessageRole};
+use rmcp::model::{ErrorData as McpError, GetPromptResult, PromptMessage, PromptMessageRole};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -19,7 +19,7 @@ pub(crate) struct AnalyzeReleaseArgs {
 }
 
 /// Generate analyze release prompt content
-pub(crate) async fn generate_prompt(args: AnalyzeReleaseArgs) -> Vec<PromptMessage> {
+pub(crate) async fn generate_prompt(args: AnalyzeReleaseArgs) -> Result<GetPromptResult, McpError> {
     let handlebars = Handlebars::new();
 
     let context = json!({
@@ -30,9 +30,17 @@ pub(crate) async fn generate_prompt(args: AnalyzeReleaseArgs) -> Vec<PromptMessa
 
     let content = handlebars
         .render_template(TEMPLATE, &context)
-        .unwrap_or_else(|e| format!("Template rendering failed: {e}"));
+        .map_err(|e| McpError::internal_error(format!("Template rendering failed: {e}"), None))?;
 
-    vec![PromptMessage::new_text(PromptMessageRole::User, content)]
+    let description = format!(
+        "Analyze how Polkadot SDK release {} impacts your project",
+        args.release
+    );
+
+    Ok(GetPromptResult {
+        description: Some(description),
+        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
+    })
 }
 
 const TEMPLATE: &str = r#"{{security_disclaimer}}

--- a/src/service/prompts/get_started.rs
+++ b/src/service/prompts/get_started.rs
@@ -1,7 +1,7 @@
 //! Beginner get started prompt implementation
 
 use handlebars::Handlebars;
-use rmcp::model::{PromptMessage, PromptMessageRole};
+use rmcp::model::{ErrorData as McpError, GetPromptResult, PromptMessage, PromptMessageRole};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -15,7 +15,7 @@ pub(crate) struct GetStartedArgs {
 }
 
 /// Generate get started prompt content
-pub(crate) async fn generate_prompt(args: GetStartedArgs) -> Vec<PromptMessage> {
+pub(crate) async fn generate_prompt(args: GetStartedArgs) -> Result<GetPromptResult, McpError> {
     let handlebars = Handlebars::new();
 
     let context = json!({
@@ -24,9 +24,12 @@ pub(crate) async fn generate_prompt(args: GetStartedArgs) -> Vec<PromptMessage> 
 
     let content = handlebars
         .render_template(TEMPLATE, &context)
-        .unwrap_or_else(|e| format!("Template rendering failed: {e}"));
+        .map_err(|e| McpError::internal_error(format!("Template rendering failed: {e}"), None))?;
 
-    vec![PromptMessage::new_text(PromptMessageRole::User, content)]
+    Ok(GetPromptResult {
+        description: Some("Get started guide for Polkadot and Substrate development".to_string()),
+        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
+    })
 }
 
 /// Get started prompt template

--- a/src/service/prompts/polkadot_upgrade/mod.rs
+++ b/src/service/prompts/polkadot_upgrade/mod.rs
@@ -3,7 +3,7 @@
 use std::env;
 
 use handlebars::Handlebars;
-use rmcp::model::{PromptMessage, PromptMessageRole};
+use rmcp::model::{ErrorData as McpError, GetPromptResult, PromptMessage, PromptMessageRole};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -22,9 +22,9 @@ pub(crate) struct PolkadotUpgradeArgs {
 }
 
 /// Generate analyze release prompt content
-pub(crate) async fn generate_prompt(args: PolkadotUpgradeArgs) -> Vec<PromptMessage> {
-    let mut messages = Vec::new();
-
+pub(crate) async fn generate_prompt(
+    args: PolkadotUpgradeArgs,
+) -> Result<GetPromptResult, McpError> {
     // Render the main prompt with context
     let handlebars = Handlebars::new();
     let context = json!({
@@ -35,11 +35,14 @@ pub(crate) async fn generate_prompt(args: PolkadotUpgradeArgs) -> Vec<PromptMess
 
     let content = handlebars
         .render_template(TEMPLATE, &context)
-        .unwrap_or_else(|e| format!("Template rendering failed: {}", e));
+        .map_err(|e| McpError::internal_error(format!("Template rendering failed: {e}"), None))?;
 
-    messages.push(PromptMessage::new_text(PromptMessageRole::User, content));
+    let description = format!("Polkadot SDK upgrade guide for release {}", args.release);
 
-    messages
+    Ok(GetPromptResult {
+        description: Some(description),
+        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
+    })
 }
 
 /// Get the project name from the current directory

--- a/src/service/prompts/scaffold_pallet.rs
+++ b/src/service/prompts/scaffold_pallet.rs
@@ -1,7 +1,7 @@
 //! Scaffold pallet prompt implementation
 
 use handlebars::Handlebars;
-use rmcp::model::{PromptMessage, PromptMessageRole};
+use rmcp::model::{ErrorData as McpError, GetPromptResult, PromptMessage, PromptMessageRole};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -17,7 +17,7 @@ pub(crate) struct ScaffoldPalletArgs {
 }
 
 /// Generate scaffold pallet prompt content
-pub(crate) async fn generate_prompt(args: ScaffoldPalletArgs) -> Vec<PromptMessage> {
+pub(crate) async fn generate_prompt(args: ScaffoldPalletArgs) -> Result<GetPromptResult, McpError> {
     let handlebars = Handlebars::new();
 
     let context = json!({
@@ -27,9 +27,12 @@ pub(crate) async fn generate_prompt(args: ScaffoldPalletArgs) -> Vec<PromptMessa
 
     let content = handlebars
         .render_template(TEMPLATE, &context)
-        .unwrap_or_else(|e| format!("Template rendering failed: {e}"));
+        .map_err(|e| McpError::internal_error(format!("Template rendering failed: {e}"), None))?;
 
-    vec![PromptMessage::new_text(PromptMessageRole::User, content)]
+    Ok(GetPromptResult {
+        description: Some("Generate pallet structure and implementation templates".to_string()),
+        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
+    })
 }
 
 /// Scaffold pallet prompt template

--- a/src/service/prompts/security_review.rs
+++ b/src/service/prompts/security_review.rs
@@ -4,7 +4,7 @@
 //! and weight analysis into a single development security review.
 
 use handlebars::Handlebars;
-use rmcp::model::{PromptMessage, PromptMessageRole};
+use rmcp::model::{ErrorData as McpError, GetPromptResult, PromptMessage, PromptMessageRole};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -20,7 +20,7 @@ pub(crate) struct SecurityReviewArgs {
 }
 
 /// Generate security review prompt content
-pub(crate) async fn generate_prompt(args: SecurityReviewArgs) -> Vec<PromptMessage> {
+pub(crate) async fn generate_prompt(args: SecurityReviewArgs) -> Result<GetPromptResult, McpError> {
     let handlebars = Handlebars::new();
 
     let context = json!({
@@ -30,9 +30,14 @@ pub(crate) async fn generate_prompt(args: SecurityReviewArgs) -> Vec<PromptMessa
 
     let content = handlebars
         .render_template(TEMPLATE, &context)
-        .unwrap_or_else(|e| format!("Template rendering failed: {e}"));
+        .map_err(|e| McpError::internal_error(format!("Template rendering failed: {e}"), None))?;
 
-    vec![PromptMessage::new_text(PromptMessageRole::User, content)]
+    let description = format!("Security review for {}", args.target);
+
+    Ok(GetPromptResult {
+        description: Some(description),
+        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
+    })
 }
 
 const TEMPLATE: &str = r#"{{security_disclaimer}}

--- a/src/service/resources.rs
+++ b/src/service/resources.rs
@@ -25,6 +25,9 @@ impl From<MarkdownResource> for Resource {
                 description: Some(val.description),
                 mime_type: Some("text/markdown".to_string()),
                 size: Some(val.content.len() as u32),
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: val.audience,
@@ -215,6 +218,9 @@ fn https_resources() -> Vec<Resource> {
                 description: Some("Index with LLM friendly Polkadot documentation. Use this to get proper context on how Polkadot works or how to perform a specific task within Polkadot or Substrate based chains (e.g: create a pallet, add benchmarks or work with XCM)".into()),
                 mime_type: None,
                 size: None,
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: Some(vec![Role::Assistant]),
@@ -229,6 +235,9 @@ fn https_resources() -> Vec<Resource> {
                 description: Some("Polkadot SDK GitHub Repository.".into()),
                 mime_type: None,
                 size: None,
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: Some(vec![Role::Assistant, Role::User]),
@@ -243,6 +252,9 @@ fn https_resources() -> Vec<Resource> {
                 description: Some("`polkadot-sdk` crate documentation".into()),
                 mime_type: None,
                 size: None,
+                icons: None,
+                meta: None,
+                title: None,
             },
             Some(Annotations {
                 audience: Some(vec![Role::Assistant, Role::User]),

--- a/src/service/tests/helpers/mcp_client.rs
+++ b/src/service/tests/helpers/mcp_client.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use rmcp::model::{CallToolRequestParam, CallToolResult};
+use rmcp::model::{
+    CallToolRequestParam, CallToolResult, GetPromptRequestParam, GetPromptResult,
+    ListPromptsResult,
+};
 use rmcp::service::{RoleClient, RunningService, ServiceExt};
 use std::borrow::Cow;
 
@@ -52,5 +55,25 @@ impl TestMcpClient {
             task: None,
         };
         Ok(self.client.call_tool(request).await?)
+    }
+
+    /// List all available prompts
+    pub(crate) async fn list_prompts(&self) -> Result<ListPromptsResult> {
+        Ok(self.client.list_prompts(None).await?)
+    }
+
+    /// Get a prompt with arguments
+    pub(crate) async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<GetPromptResult> {
+        let args = arguments.as_object().cloned();
+
+        let request = GetPromptRequestParam {
+            name: name.to_string(),
+            arguments: args,
+        };
+        Ok(self.client.get_prompt(request).await?)
     }
 }

--- a/src/service/tests/helpers/mcp_client.rs
+++ b/src/service/tests/helpers/mcp_client.rs
@@ -49,6 +49,7 @@ impl TestMcpClient {
         let request = CallToolRequestParam {
             name: Cow::from(name.to_string()),
             arguments: args,
+            task: None,
         };
         Ok(self.client.call_tool(request).await?)
     }

--- a/src/service/tests/mod.rs
+++ b/src/service/tests/mod.rs
@@ -1,2 +1,3 @@
 mod helpers;
+mod prompts;
 mod tools;

--- a/src/service/tests/prompts.rs
+++ b/src/service/tests/prompts.rs
@@ -1,0 +1,112 @@
+use super::helpers::mcp_client::TestMcpClient;
+use serde_json::json;
+
+/// Debug test to inspect what prompts/list returns
+#[tokio::test]
+async fn test_debug_list_prompts() {
+    let client = TestMcpClient::new()
+        .await
+        .expect("Failed to create MCP client");
+
+    let result = client.list_prompts().await.unwrap();
+
+    println!("\n=== DEBUG: prompts/list response ===\n");
+    println!("Number of prompts: {}", result.prompts.len());
+
+    for prompt in &result.prompts {
+        println!("\nPrompt: {}", prompt.name);
+        println!("  Description: {:?}", prompt.description);
+        println!("  Arguments: {:?}", prompt.arguments);
+
+        if let Some(args) = &prompt.arguments {
+            for arg in args {
+                println!("    - name: {}", arg.name);
+                println!("      description: {:?}", arg.description);
+                println!("      required: {:?}", arg.required);
+            }
+        }
+    }
+
+    // Find the analyze_release prompt
+    let analyze_release = result
+        .prompts
+        .iter()
+        .find(|p| p.name == "analyze_release")
+        .expect("analyze_release prompt should exist");
+
+    // Check if arguments are populated
+    assert!(
+        analyze_release.arguments.is_some(),
+        "analyze_release should have arguments defined"
+    );
+
+    let args = analyze_release.arguments.as_ref().unwrap();
+    assert!(
+        !args.is_empty(),
+        "analyze_release should have at least one argument"
+    );
+
+    // Check for the release argument
+    let release_arg = args
+        .iter()
+        .find(|a| a.name == "release")
+        .expect("Should have release argument");
+
+    println!("\n=== Release argument found ===");
+    println!("  name: {}", release_arg.name);
+    println!("  description: {:?}", release_arg.description);
+    println!("  required: {:?}", release_arg.required);
+}
+
+/// Test that prompts/get works with arguments
+#[tokio::test]
+async fn test_get_prompt_with_arguments() {
+    let client = TestMcpClient::new()
+        .await
+        .expect("Failed to create MCP client");
+
+    let args = json!({"release": "stable2503"});
+    let result = client.get_prompt("analyze_release", args).await;
+
+    match &result {
+        Ok(prompt_result) => {
+            println!("\n=== DEBUG: prompts/get response ===\n");
+            println!("Description: {:?}", prompt_result.description);
+            println!("Messages count: {}", prompt_result.messages.len());
+            // Print first part of first message if available
+            if let Some(msg) = prompt_result.messages.first() {
+                println!("First message role: {:?}", msg.role);
+            }
+        }
+        Err(e) => {
+            println!("\n=== ERROR: prompts/get failed ===\n");
+            println!("Error: {:?}", e);
+        }
+    }
+
+    assert!(
+        result.is_ok(),
+        "Should successfully get prompt with arguments: {:?}",
+        result.err()
+    );
+}
+
+/// Test that the focus optional argument works
+#[tokio::test]
+async fn test_get_prompt_with_optional_focus() {
+    let client = TestMcpClient::new()
+        .await
+        .expect("Failed to create MCP client");
+
+    let args = json!({
+        "release": "stable2503",
+        "focus": "security"
+    });
+    let result = client.get_prompt("analyze_release", args).await;
+
+    assert!(
+        result.is_ok(),
+        "Should successfully get prompt with release and focus: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Summary

- Update prompt handler return types from `Vec<PromptMessage>` to `Result<GetPromptResult, McpError>` (required by rmcp 0.13.0 API)
- Add `preserve_order` feature to schemars to fix positional argument mapping bug
- Add prompt integration tests

## Problem

After upgrading to rmcp 0.13.0, prompts failed with "missing field release" errors when using positional arguments (e.g., `/substrate:analyze_release stable2503`). This was caused by:

1. rmcp 0.13.0 changed the expected return type for prompt handlers
2. schemars was alphabetizing schema properties, causing `focus` to appear before `release`, so positional args mapped incorrectly

## Test plan

- [x] `cargo test` passes
- [x] Verify `/substrate:analyze_release stable2503` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)